### PR TITLE
Make pod storage immutable after creation

### DIFF
--- a/src/apiserver/controller/types.py
+++ b/src/apiserver/controller/types.py
@@ -365,9 +365,8 @@ class PodUpdateRequest(BaseModel):
     @field_validator('storage_lim_mb')
     def storage_lim_mb_must_be_valid(cls, v):
         if v is not None:
-            return PodCreateRequest.storage_lim_mb_must_be_valid(v)
-        else:
-            return v
+            raise ValueError('storage cannot be changed after pod creation')
+        return v
 
     @field_validator('gpu')
     def gpu_must_be_valid(cls, v):

--- a/src/apiserver/service/pod.py
+++ b/src/apiserver/service/pod.py
@@ -196,7 +196,6 @@ class PodService(ServiceInterface):
         spec_requested = any([
             req.cpu_lim_m_cpu is not None,
             req.mem_lim_mb is not None,
-            req.storage_lim_mb is not None,
             req.gpu is not None,
         ])
 
@@ -209,12 +208,12 @@ class PodService(ServiceInterface):
         # Effective spec used for both the quota check and the persisted update.
         effective_cpu = req.cpu_lim_m_cpu if req.cpu_lim_m_cpu is not None else old_pod.cpu_lim_m_cpu
         effective_mem = req.mem_lim_mb if req.mem_lim_mb is not None else old_pod.mem_lim_mb
-        effective_storage = req.storage_lim_mb if req.storage_lim_mb is not None else old_pod.storage_lim_mb
         effective_gpu = req.gpu if req.gpu is not None else old_pod.gpu
 
         req.cpu_lim_m_cpu = effective_cpu
         req.mem_lim_mb = effective_mem
-        req.storage_lim_mb = effective_storage
+        # Storage is fixed at creation; always use the existing value for the quota check.
+        req.storage_lim_mb = old_pod.storage_lim_mb
         req.gpu = effective_gpu
 
         # Enforce the user's quota using the effective spec (covers both spec edits
@@ -233,7 +232,7 @@ class PodService(ServiceInterface):
             target_status=req.target_status,
             cpu_lim_m_cpu=effective_cpu if spec_requested else None,
             mem_lim_mb=effective_mem if spec_requested else None,
-            storage_lim_mb=effective_storage if spec_requested else None,
+            storage_lim_mb=None,
             gpu=effective_gpu if spec_requested else None,
         )
 

--- a/tests/test_pod_edit_and_scheduling.py
+++ b/tests/test_pod_edit_and_scheduling.py
@@ -63,36 +63,22 @@ def _update_req(
         target_status: datamodels.PodStatusEnum = None,
         cpu: int = None,
         mem: int = None,
-        storage: int = None,
         gpu: int = None,
 ) -> PodUpdateRequest:
     return PodUpdateRequest(
         pod_id=pod_id,
         cpu_lim_m_cpu=cpu,
         mem_lim_mb=mem,
-        storage_lim_mb=storage,
         gpu=gpu,
         target_status=target_status,
     )
 
 
-def test_check_quota_update_storage_exceeded_even_when_not_starting():
-    """Storage is charged regardless of running state — editing a stopped pod's
-    storage must respect the storage quota."""
-    user = _new_user(storage_mb=20480)
-    pod = _new_pod(storage=10240, status=datamodels.PodStatusEnum.stopped, pod_id="a")
-    other = _new_pod(storage=10240, status=datamodels.PodStatusEnum.stopped, pod_id="b")
-    req = _update_req("a", storage=20480)  # 20G + 10G > 20G quota
-
-    assert PodService.check_quota(user, [pod, other], req, mode=ModeEnum.update) is False
-
-
-def test_check_quota_update_storage_ok_when_within_limit():
-    user = _new_user(storage_mb=20480)
-    pod = _new_pod(storage=10240, status=datamodels.PodStatusEnum.stopped, pod_id="a")
-    req = _update_req("a", storage=15360)
-
-    assert PodService.check_quota(user, [pod], req, mode=ModeEnum.update) is True
+def test_update_request_rejects_storage_change():
+    """Storage is immutable after pod creation; the request validator must reject it."""
+    import pytest
+    with pytest.raises(Exception):
+        PodUpdateRequest(pod_id="a", storage_lim_mb=20480)
 
 
 def test_check_quota_update_running_counts_other_running_pods_only():
@@ -196,7 +182,6 @@ def _spec_update_req(pod_id, force=False):
         pod_id=pod_id,
         cpu_lim_m_cpu=2000,
         mem_lim_mb=2048,
-        storage_lim_mb=20480,
         force=force,
     )
 


### PR DESCRIPTION
## Summary
This change enforces that pod storage is immutable after creation. Storage can only be set during pod creation and cannot be modified through update requests.

## Key Changes
- **PodUpdateRequest validation**: Added a validator that rejects any attempt to change `storage_lim_mb` in update requests with a clear error message
- **Pod update logic**: Removed storage from the list of fields that can be modified; storage now always uses the existing pod value for quota checks and is never persisted as part of an update
- **Test updates**: 
  - Removed tests that validated storage quota checks during pod updates (no longer applicable)
  - Added new test to verify that `PodUpdateRequest` rejects storage changes
  - Updated test fixtures to remove storage parameters from update request builders

## Implementation Details
- The `PodUpdateRequest.storage_lim_mb_must_be_valid` validator now raises a `ValueError` if storage is provided, making it impossible to create an update request with storage modifications
- During pod updates, storage is explicitly set to the old pod's value for quota enforcement, ensuring consistent behavior
- The persisted update operation no longer includes storage changes (`storage_lim_mb=None`)
- This change maintains backward compatibility for pod creation while preventing accidental or intentional storage modifications post-creation

https://claude.ai/code/session_012yq9heoECnETH7jZ6jvm5b