### PR TITLE
Support pod template switching with selective resource cleanup

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -544,6 +544,7 @@ All payload fields are optional; omitted fields are left unchanged. Limited to a
     {
         "name": "",
         "description": "",
+        "template_ref": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "cpu_lim_m_cpu": 1000,
         "mem_lim_mb": 1024,
         "storage_lim_mb": 10240,
@@ -860,6 +861,11 @@ so a pod must always be stopped before its spec can be changed. This lets a
 user shrink a pod whose original spec no longer fits the cluster's available
 resources, then start it.
 
+`template_ref` can also be changed while the pod is `stopped`. The target
+template must be in `committed` state. On the next start, old Kubernetes
+resources (Deployment, Service, Ingress) are replaced with those from the new
+template; PersistentVolumeClaims are preserved so existing data is not lost.
+
 Every request — whether it changes specs, just sets `target_status: running`,
 or both — is validated against the user's quota using the *effective* spec
 (request value falling back to the pod's stored value), so a user can never
@@ -883,6 +889,7 @@ edit the spec and retry.
     {
         "name": "",
         "description": "",
+        "template_ref": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "cpu_lim_m_cpu": 1000,
         "mem_lim_mb": 1024,
         "storage_lim_mb": 10240,
@@ -908,6 +915,8 @@ edit the spec and retry.
     ```json
     {"status": 400, "message": "pod must be stopped to edit its specs"}
     {"status": 400, "message": "quota exceeded"}
+    {"status": 400, "message": "template is not committed"}
+    {"status": 404, "message": "template not found"}
     ```
 
 #### DELETE /v1/pods/:pod_id

--- a/docs/datamodels.md
+++ b/docs/datamodels.md
@@ -19,7 +19,7 @@
 - **name**: name, string, mutable
 - **description**: name, string, mutable
 - **image_ref**: reference of image, string, mutable
-- **template_ref**: unique id of template, uuid, immutable 
+- **template_ref**: unique id of template, uuid, mutable when pod is `stopped` (must reference a `committed` template)
 - **template_str**: string copy of template, string, immutable
 - **cpu_lim_m_cpu**: limit of cpu (mCPU), integer, mutable when pod is `stopped`
 - **mem_lim_mb**: limit of memory (MB), integer, mutable when pod is `stopped`

--- a/src/apiserver/controller/types.py
+++ b/src/apiserver/controller/types.py
@@ -317,6 +317,7 @@ class PodUpdateRequest(BaseModel):
     pod_id: Optional[str]
     name: Optional[str] = None
     description: Optional[str] = None
+    template_ref: Optional[str] = None
     cpu_lim_m_cpu: Optional[int] = None
     mem_lim_mb: Optional[int] = None
     storage_lim_mb: Optional[int] = None
@@ -366,6 +367,16 @@ class PodUpdateRequest(BaseModel):
     def storage_lim_mb_must_be_valid(cls, v):
         if v is not None:
             raise ValueError('storage cannot be changed after pod creation')
+        return v
+
+    @field_validator('template_ref')
+    def template_ref_must_be_valid(cls, v):
+        if v is None:
+            return v
+        try:
+            _ = uuid.UUID(v)
+        except ValueError as e:
+            raise e
         return v
 
     @field_validator('gpu')

--- a/src/apiserver/repo/pod.py
+++ b/src/apiserver/repo/pod.py
@@ -133,6 +133,7 @@ class PodRepo:
             user_uuid: Optional[str] = None,
             timeout_s: Optional[int] = None,
             target_status: Optional[datamodels.PodStatusEnum] = None,
+            template_ref: Optional[str] = None,
             cpu_lim_m_cpu: Optional[int] = None,
             mem_lim_mb: Optional[int] = None,
             storage_lim_mb: Optional[int] = None,
@@ -168,6 +169,8 @@ class PodRepo:
                 pod['timeout_s'] = timeout_s if timeout_s is not None else pod['timeout_s']
                 pod['target_status'] = target_status if target_status is not None else pod['target_status']
 
+                pod['template_ref'] = template_ref if template_ref is not None else pod['template_ref']
+
                 # spec fields (editable only when pod is stopped; enforced by the service layer)
                 pod['cpu_lim_m_cpu'] = cpu_lim_m_cpu if cpu_lim_m_cpu is not None else pod['cpu_lim_m_cpu']
                 pod['mem_lim_mb'] = mem_lim_mb if mem_lim_mb is not None else pod['mem_lim_mb']
@@ -186,10 +189,11 @@ class PodRepo:
                 elif current_status_reason is not None:
                     pod['current_status_reason'] = current_status_reason
 
-                # if username, target_status, or any spec field is changed, set resource_status to pending
+                # if username, target_status, template_ref, or any spec field is changed, set resource_status to pending
                 if any([
                     username is not None,
                     target_status is not None,
+                    template_ref is not None,
                     cpu_lim_m_cpu is not None,
                     mem_lim_mb is not None,
                     storage_lim_mb is not None,

--- a/src/apiserver/service/handler.py
+++ b/src/apiserver/service/handler.py
@@ -233,6 +233,16 @@ async def handle_pod_create_update_event(srv: Optional['src.apiserver.service.Ro
         logger.error(f"handle_pod_create_update_event failed to parse template {pod.template_ref}: {err}")
         return err
 
+    # If the template content changed since the last successful apply, delete old
+    # non-PVC resources so stale Deployments/Services from the previous template
+    # are removed before the new manifest is applied.
+    if pod.template_str is not None and pod.template_str != "" and pod.template_str != original_template_str:
+        logger.info(f"template changed for pod {pod.pod_id}, cleaning up non-PVC resources")
+        err = await srv.k8s_operator_service.delete_pod_except_pvc(pod.pod_id)
+        if err is not None:
+            logger.error(f"handle_pod_create_update_event failed to clean up old resources for pod {pod.pod_id}: {err}")
+            return err
+
     # create pod ingress
     ingress_resource = K8SIngressResource.new(pod, srv.opt)
     err = await srv.k8s_operator_service.create_apply_ingress(ingress_resource)

--- a/src/apiserver/service/operator.py
+++ b/src/apiserver/service/operator.py
@@ -372,6 +372,37 @@ class K8SOperatorService(ServiceInterface):
         logger.info(f"pod {pod_id} deleted successfully")
         return None
 
+    async def delete_pod_except_pvc(self, pod_id: str) -> Optional[Exception]:
+        """
+        Delete all K8s resources for a pod except PersistentVolumeClaims.
+        Used when switching templates so old non-storage resources are removed
+        before the new template is applied.
+        """
+        pod_label = CONFIG_K8S_POD_LABEL_FMT.format(pod_id)
+        skipped_kinds = {'PersistentVolumeClaim'}
+
+        try:
+            for kind, col in self._resource_function_map.items():
+                if kind in skipped_kinds:
+                    continue
+                resources = col['list'](
+                    self.namespace,
+                    label_selector=f"{CONFIG_K8S_POD_LABEL_KEY}={pod_label}"
+                )
+                for resource in resources.items:
+                    col['delete'](resource.metadata.name, self.namespace)
+
+        except ApiException as e:
+            logger.exception(e)
+            return e
+
+        except Exception as e:
+            logger.exception(e)
+            return e
+
+        logger.info(f"pod {pod_id} non-PVC resources deleted for template switch")
+        return None
+
     async def _apply_k8s_resource(self, resource: dict) -> Optional[Exception]:
         """
         Apply k8s resource, similar to kubectl apply

--- a/src/apiserver/service/pod.py
+++ b/src/apiserver/service/pod.py
@@ -192,6 +192,18 @@ class PodService(ServiceInterface):
         # list all pods of the user
         _, pods, err = await self.parent.pod_service.repo.list(extra_query_filter={"username": req.username})
 
+        # Validate and resolve template_ref switch.
+        if req.template_ref is not None and req.template_ref != str(old_pod.template_ref):
+            if old_pod.current_status != datamodels.PodStatusEnum.stopped:
+                return None, errors.pod_not_stopped
+            new_template, err = await self.parent.template_service.repo.get(req.template_ref)
+            if err is not None or new_template is None:
+                return None, errors.template_not_found
+            if new_template.resource_status != datamodels.ResourceStatusEnum.committed:
+                return None, errors.template_not_committed
+        else:
+            req.template_ref = None  # no change, do not write to repo
+
         # Determine whether the user requested a spec change.
         spec_requested = any([
             req.cpu_lim_m_cpu is not None,
@@ -230,6 +242,7 @@ class PodService(ServiceInterface):
             user_uuid=req.user_uuid,
             timeout_s=req.timeout_s,
             target_status=req.target_status,
+            template_ref=req.template_ref,
             cpu_lim_m_cpu=effective_cpu if spec_requested else None,
             mem_lim_mb=effective_mem if spec_requested else None,
             storage_lim_mb=None,

--- a/src/components/errors.py
+++ b/src/components/errors.py
@@ -25,6 +25,7 @@ quota_exceeded = Exception("quota exceeded")
 template_invalid = Exception("template invalid")
 template_key_not_exists = BaseException("template key not exists")
 template_key_not_used = Exception("template key not used")
+template_not_committed = Exception("template is not committed")
 template_not_found = Exception("template not found")
 unknown_error = Exception("unknown error")
 user_not_found = Exception("user not found")
@@ -46,6 +47,8 @@ USER_ERROR_HTTP_STATUS = {
     id(invalid_request_body): http.HTTPStatus.BAD_REQUEST,
     id(wrong_pod_profile): http.HTTPStatus.BAD_REQUEST,
     id(pod_not_found): http.HTTPStatus.NOT_FOUND,
+    id(template_not_found): http.HTTPStatus.NOT_FOUND,
+    id(template_not_committed): http.HTTPStatus.BAD_REQUEST,
     id(user_not_found): http.HTTPStatus.NOT_FOUND,
     id(username_required): http.HTTPStatus.BAD_REQUEST,
     id(user_not_allowed): http.HTTPStatus.FORBIDDEN,


### PR DESCRIPTION
## Summary
This PR adds support for switching pod templates while preserving persistent storage. When a pod's template is changed, the system now validates the template change, cleans up old non-storage Kubernetes resources from the previous template, and applies the new template configuration.

## Key Changes

- **New template switching validation** (`pod.py`): Added validation logic to ensure pods are stopped before template changes and that the new template exists and is committed
- **Selective resource cleanup** (`operator.py`): Introduced `delete_pod_except_pvc()` method to remove all Kubernetes resources except PersistentVolumeClaims, allowing safe template transitions without data loss
- **Template change detection** (`handler.py`): Added logic to detect when template content has changed and trigger cleanup of old resources before applying the new manifest
- **Data model updates** (`types.py`, `pod.py`, `repo.py`): Extended `PodUpdateRequest` and pod repository to support `template_ref` field with UUID validation
- **Resource status management** (`repo.py`): Updated resource status to pending when template is changed, ensuring proper reconciliation
- **Error handling** (`errors.py`): Added `template_not_committed` error with appropriate HTTP status mapping

## Implementation Details

- Template switching is only allowed when the pod is in stopped status
- The new template must exist and have committed status before the switch
- Old non-PVC resources are cleaned up before the new template is applied, preventing conflicts between old and new deployments
- PersistentVolumeClaims are explicitly preserved during cleanup to maintain data persistence
- Template reference changes trigger resource status to pending, initiating the reconciliation process

https://claude.ai/code/session_01MjTLsbNw4SywJfAuzLUZoH