### PR TITLE
ci: trigger image publish workflow on version tag pushes

### DIFF
--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -6,6 +6,7 @@ name: build-release-image
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
Adds tags: ["v*"] to the push trigger so the build-release-image workflow fires when a release tag is created, not just on branch pushes. The Makefile already uses git describe --tags for the image tag, so versioned images are published automatically on release.

https://claude.ai/code/session_01NsBHXgKbmeJjcxR19wvN8h