### PR TITLE
Add template enabled/disabled feature and dynamic build versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ AUTHOR="davidliyutong"
 DEV_AUTHOR="davidliyutong"
 
 build.docker.native:
-	docker build -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -f manifests/docker/Dockerfile .
+	docker build --build-arg GIT_VERSION=${GIT_VERSION} -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -f manifests/docker/Dockerfile .
 	docker tag ${AUTHOR}/clpl-apiserver:${GIT_VERSION} davidliyutong/clpl-apiserver:latest
 
 build.docker.buildx:
-	docker buildx build --platform=linux/amd64,linux/arm64 -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
-	docker buildx build --load -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
+	docker buildx build --build-arg GIT_VERSION=${GIT_VERSION} --platform=linux/amd64,linux/arm64 -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
+	docker buildx build --build-arg GIT_VERSION=${GIT_VERSION} --load -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
 
 push.docker.buildx:
-	docker buildx build --push --platform=linux/amd64,linux/arm64 -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
+	docker buildx build --build-arg GIT_VERSION=${GIT_VERSION} --push --platform=linux/amd64,linux/arm64 -t ${AUTHOR}/clpl-apiserver:${GIT_VERSION} -t ${AUTHOR}/clpl-apiserver:latest -f manifests/docker/Dockerfile .
 
 test.docker:
 	docker run --rm -it --net=host -p 8080:8080 ${AUTHOR}/clpl-apiserver:latest
@@ -20,4 +20,4 @@ task.generate_client:
 	openapi-generator-cli generate -g python -i http://127.0.0.1:8080/docs/openapi.json --skip-validate-spec -o python-client
 
 dev.push:
-	docker buildx build --push --platform=linux/amd64,linux/arm64 -t ${DEV_AUTHOR}/clpl-apiserver:latest-dev -f manifests/docker/Dockerfile .
+	docker buildx build --build-arg GIT_VERSION=${GIT_VERSION} --push --platform=linux/amd64,linux/arm64 -t ${DEV_AUTHOR}/clpl-apiserver:latest-dev -f manifests/docker/Dockerfile .

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,9 +251,10 @@ This section describes admin APIs that manipulate template resource.
 
 #### GET /v1/admin/templates
 
-List all templates. If `template_id_start` and `template_id_end` are “greater than” 0, only templates with `template_id`
-between `template_id_start` and `template_id_end` are returned. If `filter` is not empty, apply filter on results. This
-API returns profiles of templates and total number of templates. Limited to admins.
+List all templates, including disabled ones. If `index_start` and `index_end`
+are greater than 0 they slice the result window. `extra_query_filter` accepts
+an additional MongoDB filter (JSON). Returns profiles of templates and total
+count. Limited to admins.
 
 - Request Header:
 
@@ -353,6 +354,12 @@ Get a single template. Limited to admins.
 
 Modify template. Payload is new template profile. Limited to admins.
 
+All payload fields are optional; omitted fields are left unchanged.
+
+Setting `enabled` to `false` hides the template from non-admin users without
+deleting it. Non-admin list and get endpoints treat disabled templates as
+non-existent (404). Admins can always see and toggle disabled templates.
+
 - Request Header:
 
     ```conf
@@ -366,10 +373,12 @@ Modify template. Payload is new template profile. Limited to admins.
     { 
         "template_id": "",
         "name": "",
+        "description": "",
         "image_ref": "",
         "template_str": "", 
         "fields": {},
-        "defaults": {} 
+        "defaults": {},
+        "enabled": true
     }
     ```
 
@@ -664,13 +673,16 @@ Modify user. Payload is new user profile. Similar to /v1/admin/user/:username. U
     ```
 ### Templates Management
 
-This section describes user APIs that read template resource.
+This section describes user APIs that read template resource. Only templates
+with `enabled: true` are visible through these endpoints — disabled templates
+are treated as non-existent and return 404.
 
-#### GET /v1/admin/templates
+#### GET /v1/templates
 
-List all templates. If `template_id_start` and `template_id_end` are “greater than” 0, only templates with `template_id`
-between `template_id_start` and `template_id_end` are returned. If `filter` is not empty, apply filter on results. This
-API returns profiles of templates and total number of templates.
+List enabled templates. Disabled templates are automatically excluded.
+If `index_start` and `index_end` are greater than 0 they slice the result
+window. `extra_query_filter` accepts an additional MongoDB filter (JSON) that
+is merged with the mandatory `{“enabled”: true}` constraint.
 
 - Request Header:
 
@@ -678,36 +690,31 @@ API returns profiles of templates and total number of templates.
     Authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey
     Content-Type=application/json
     ```
-
-- Request Payload:
-    ```
-    ```
-
 
 - Request Query:
 
     ```conf
-     "index_start"= -1
-     "index_end"= -1,
-     "filter"= ""
+     “index_start”= -1
+     “index_end”= -1,
+     “extra_query_filter”= “”
     ```
 
 - Response:
 
     ```json
     {
-        "description": "",
-        "status":200,
-        "message":"",
-        "total_templates": 1,
-        "templates": []
+        “description”: “”,
+        “status”:200,
+        “message”:””,
+        “total_templates”: 1,
+        “templates”: []
     }
     ```
-  
 
-#### GET /v1/admin/templates/:template_id
+#### GET /v1/templates/:template_id
 
-Get a single template. Limited to admins.
+Get a single enabled template. Returns 404 if the template does not exist
+or has been disabled by an admin.
 
 - Request Header:
 
@@ -716,20 +723,22 @@ Get a single template. Limited to admins.
     Content-Type=application/json
     ```
 
-- Request Payload:
-
-    ```json
-    ```
-
 - Response:
 
     ```json
     {
-        "description": "",
-        "status":200,
-        "message":"",
-        "template": {}
+        “description”: “”,
+        “status”:200,
+        “message”:””,
+        “template”: {}
     }
+    ```
+
+- Error responses:
+
+    ```json
+    {“status”: 404, “message”: “template not found”}
+    {“status”: 404, “message”: “template is disabled”}
     ```
 
 ### Pod Management

--- a/manifests/docker/Dockerfile
+++ b/manifests/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.11-bookworm
 WORKDIR /opt/app
 ENV PYTHONPATH "${PYTHONPATH}:/opt/app"
 
+ARG GIT_VERSION=dev
+ENV CLPL_BUILD_VERSION=${GIT_VERSION}
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/src/apiserver/controller/admin_template.py
+++ b/src/apiserver/controller/admin_template.py
@@ -198,7 +198,8 @@ async def get(request, template_id: str):
 @authn.validate_role(role=("admin", "super_admin"))
 async def update(request, template_id: str):
     """
-    Update a template.
+    Update a template. Supports toggling the enabled field to hide/show
+    the template from non-admin users without deleting it.
     """
     logger.debug(f"{request.method} {request.path} invoked")
 

--- a/src/apiserver/controller/nonadmin_template.py
+++ b/src/apiserver/controller/nonadmin_template.py
@@ -35,7 +35,8 @@ bp = Blueprint("nonadmin_template", url_prefix="/templates", version=1)
 @protected()
 async def list(request):
     """
-    List all templates. The same as admin_template_list, but without role check.
+    List enabled templates. Only templates with enabled=true are returned;
+    disabled templates are invisible to non-admin users.
     """
     logger.debug(f"{request.method} {request.path} invoked")
 
@@ -88,7 +89,7 @@ async def list(request):
 @protected()
 async def get(request, template_id: str):
     """
-    Get a template by id. The same as admin_template_get, but without role check.
+    Get a template by id. Returns 404 if the template does not exist or is disabled.
     """
     logger.debug(f"{request.method} {request.path} invoked")
 

--- a/src/apiserver/controller/nonadmin_template.py
+++ b/src/apiserver/controller/nonadmin_template.py
@@ -3,6 +3,7 @@ This module implements the non-admin template controller.
 """
 
 import http
+import json
 
 from loguru import logger
 from sanic import Blueprint
@@ -42,6 +43,14 @@ async def list(request):
         req = TemplateListRequest()
     else:
         req = TemplateListRequest(**{k: v for (k, v) in request.query_args})
+
+    # merge enabled=True filter so non-admin users only see enabled templates
+    try:
+        base_filter = json.loads(req.extra_query_filter) if req.extra_query_filter else {}
+    except json.JSONDecodeError:
+        base_filter = {}
+    base_filter["enabled"] = True
+    req.extra_query_filter = json.dumps(base_filter)
 
     # list templates
     count, templates, err = await get_root_service().template_service.list(request.app, req)
@@ -97,14 +106,19 @@ async def get(request, template_id: str):
         req = TemplateGetRequest(template_id=template_id)
         template, err = await get_root_service().template_service.get(request.app, req)
 
+        # treat disabled templates as not found for non-admin users
+        if err is None and not template.enabled:
+            err = errors.template_disabled
+            template = None
+
         # return response
         if err is not None:
             return json_response(
                 TemplateGetResponse(
-                    status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                    status=http.HTTPStatus.NOT_FOUND,
                     message=str(err)
                 ).model_dump(),
-                status=http.HTTPStatus.INTERNAL_SERVER_ERROR
+                status=http.HTTPStatus.NOT_FOUND
             )
         else:
             return json_response(

--- a/src/apiserver/controller/types.py
+++ b/src/apiserver/controller/types.py
@@ -189,6 +189,7 @@ class TemplateUpdateRequest(BaseModel):
     template_str: Optional[str] = None
     fields: Optional[Dict[str, Any]] = None
     defaults: Optional[Dict[str, Any]] = None
+    enabled: Optional[bool] = None
 
 
 class TemplateUpdateResponse(TemplateGetResponse):

--- a/src/apiserver/repo/template.py
+++ b/src/apiserver/repo/template.py
@@ -123,7 +123,8 @@ class TemplateRepo:
             image_ref: Optional[str],
             template_str: Optional[str],
             fields: Optional[Dict[str, Any]],
-            defaults: Optional[Dict[str, Any]]
+            defaults: Optional[Dict[str, Any]],
+            enabled: Optional[bool] = None,
     ) -> Tuple[Optional[datamodels.TemplateModel], Optional[Exception]]:
         """
         Update a template.
@@ -147,6 +148,7 @@ class TemplateRepo:
                 template['template_str'] = template_str if template_str is not None else template['template_str']
                 template['fields'] = fields if fields is not None else template['fields']
                 template['defaults'] = defaults if defaults is not None else template['defaults']
+                template['enabled'] = enabled if enabled is not None else template.get('enabled', True)
                 template['resource_status'] = datamodels.ResourceStatusEnum.pending.value
 
                 # check if the template model is valid

--- a/src/apiserver/service/template.py
+++ b/src/apiserver/service/template.py
@@ -85,7 +85,8 @@ class TemplateService(ServiceInterface):
                                                image_ref=req.image_ref,
                                                template_str=req.template_str,
                                                fields=req.fields,
-                                               defaults=req.defaults)
+                                               defaults=req.defaults,
+                                               enabled=req.enabled)
 
         # if success and target_status is pending, trigger template update event
         if err is None and template.resource_status == datamodels.ResourceStatusEnum.pending:

--- a/src/components/config.py
+++ b/src/components/config.py
@@ -12,7 +12,26 @@ from loguru import logger
 from pydantic import BaseModel
 from vyper import Vyper
 
-CONFIG_BUILD_VERSION = "v0.0.8"
+def _resolve_build_version() -> str:
+    # 1. Injected at build time (e.g. Docker --build-arg → ENV CLPL_BUILD_VERSION)
+    v = os.environ.get("CLPL_BUILD_VERSION", "")
+    if v:
+        return v
+    # 2. Runtime git describe (local dev)
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0", "--always"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "dev"
+
+
+CONFIG_BUILD_VERSION = _resolve_build_version()
 CONFIG_HOME_PATH = os.path.expanduser('~')
 CONFIG_CONFIG_NAME = "apiserver"
 CONFIG_PROJECT_NAME = "clpl"

--- a/src/components/datamodels.py
+++ b/src/components/datamodels.py
@@ -300,6 +300,7 @@ class TemplateModel(BaseModel):
     template_str: str
     fields: Optional[Dict[str, FieldTypeEnum]]  # not used
     defaults: Optional[Dict[str, Any]]  # not used
+    enabled: bool = True
 
     @field_validator("version")
     def version_must_be_valid(cls, v):
@@ -335,7 +336,8 @@ class TemplateModel(BaseModel):
             image_ref: str,
             template_str: str,
             fields: Optional[Dict[str, Any]],
-            defaults: Optional[Dict[str, Any]]):
+            defaults: Optional[Dict[str, Any]],
+            enabled: bool = True):
         return cls(
             version=config.CONFIG_BUILD_VERSION,
             template_id=uuid.uuid4(),
@@ -345,6 +347,7 @@ class TemplateModel(BaseModel):
             template_str=template_str,
             fields=fields,
             defaults=defaults,
+            enabled=enabled,
         )
 
     # example values to test if template is valid

--- a/src/components/errors.py
+++ b/src/components/errors.py
@@ -26,6 +26,7 @@ template_invalid = Exception("template invalid")
 template_key_not_exists = BaseException("template key not exists")
 template_key_not_used = Exception("template key not used")
 template_not_committed = Exception("template is not committed")
+template_disabled = Exception("template is disabled")
 template_not_found = Exception("template not found")
 unknown_error = Exception("unknown error")
 user_not_found = Exception("user not found")
@@ -47,6 +48,7 @@ USER_ERROR_HTTP_STATUS = {
     id(invalid_request_body): http.HTTPStatus.BAD_REQUEST,
     id(wrong_pod_profile): http.HTTPStatus.BAD_REQUEST,
     id(pod_not_found): http.HTTPStatus.NOT_FOUND,
+    id(template_disabled): http.HTTPStatus.NOT_FOUND,
     id(template_not_found): http.HTTPStatus.NOT_FOUND,
     id(template_not_committed): http.HTTPStatus.BAD_REQUEST,
     id(user_not_found): http.HTTPStatus.NOT_FOUND,


### PR DESCRIPTION
## Summary

This PR introduces template enable/disable functionality for access control and implements dynamic build version resolution that supports both Docker build-time injection and local development git-based versioning.

## Key Changes

### Template Enable/Disable Feature
- Added `enabled: bool = True` field to `TemplateModel` dataclass with default enabled state
- Non-admin users now only see enabled templates:
  - `list()` endpoint automatically filters to `enabled=True`
  - `get()` endpoint treats disabled templates as not found (404 instead of 500)
- Added `template_disabled` error type mapped to HTTP 404 status
- Updated `TemplateUpdateRequest` to accept optional `enabled` parameter for admin updates
- Template repository and service layers now support enabling/disabling via update operations

### Dynamic Build Versioning
- Replaced hardcoded `CONFIG_BUILD_VERSION = "v0.0.8"` with `_resolve_build_version()` function that:
  1. Checks `CLPL_BUILD_VERSION` environment variable (set by Docker `--build-arg`)
  2. Falls back to `git describe --tags --abbrev=0 --always` for local development
  3. Defaults to `"dev"` if both fail
- Updated Dockerfile to accept `GIT_VERSION` build argument and set `CLPL_BUILD_VERSION` environment variable
- Updated all Makefile docker build commands to pass `--build-arg GIT_VERSION=${GIT_VERSION}`

## Implementation Details

- Template filtering in non-admin list endpoint uses JSON merge pattern to preserve existing `extra_query_filter` while enforcing `enabled=True`
- Build version resolution is lazy-evaluated at module import time, supporting both containerized and local development workflows
- Error handling in version resolution is defensive (catches all exceptions, returns sensible default)
- HTTP status code for disabled template access changed from 500 (INTERNAL_SERVER_ERROR) to 404 (NOT_FOUND) for consistency with not-found semantics

https://claude.ai/code/session_011T3orZv5jKyyMSxYg7zD5p